### PR TITLE
Add items routing according to user types

### DIFF
--- a/backend/src/controllers/items.ts
+++ b/backend/src/controllers/items.ts
@@ -24,7 +24,9 @@ interface ItemUpdateRequest {
     quantity?: number;
   }
 
-const itemsRouter = Router();
+const privateItemsRouter = Router();
+const publicItemsRouter = Router();
+const adminItemsRouter = Router();
 
 const itemFinder = async (req: ItemRequest, _res: Response, next: NextFunction) => {
   const id = parseInt(req.params.id, 10);
@@ -32,13 +34,13 @@ const itemFinder = async (req: ItemRequest, _res: Response, next: NextFunction) 
   next();
 };
 
-itemsRouter.get("/", async (_req: Request, res: Response) => {
+publicItemsRouter.get("/", async (_req: Request, res: Response) => {
   const items = await itemService.findAll();
   res.json(items);
 });
 
 // Get items by category
-itemsRouter.get("/category/:categoryId", async (req: Request, res: Response, next: NextFunction) => {
+publicItemsRouter.get("/category/:categoryId", async (req: Request, res: Response, next: NextFunction) => {
   try {
     const categoryId = parseInt(req.params.categoryId, 10);
     const items = await itemService.findByCategory(categoryId);
@@ -49,7 +51,7 @@ itemsRouter.get("/category/:categoryId", async (req: Request, res: Response, nex
 });
 
 // Search items by name or description
-itemsRouter.get("/search", async (req: Request, res: Response, next: NextFunction) => {
+publicItemsRouter.get("/search", async (req: Request, res: Response, next: NextFunction) => {
   try {
     const query = req.query.q as string;
     if (!query) {
@@ -64,7 +66,7 @@ itemsRouter.get("/search", async (req: Request, res: Response, next: NextFunctio
   }
 });
 
-itemsRouter.post("/", async (req: Request<{}, {}, ItemCreationAttributes>, res: Response, next: NextFunction) => {
+privateItemsRouter.post("/", async (req: Request<{}, {}, ItemCreationAttributes>, res: Response, next: NextFunction) => {
   try {
     console.log('Creating item with data:', req.body);
     const item = await itemService.create(req.body);
@@ -76,7 +78,7 @@ itemsRouter.post("/", async (req: Request<{}, {}, ItemCreationAttributes>, res: 
   }
 });
 
-itemsRouter.get('/:id', (req: Request, res: Response, next: NextFunction) => itemFinder(req as ItemRequest, res, next), (req, res) => {
+privateItemsRouter.get('/:id', (req: Request, res: Response, next: NextFunction) => itemFinder(req as ItemRequest, res, next), (req, res) => {
     if ((req as ItemRequest).item) {
         res.json((req as ItemRequest).item);
     } else {
@@ -84,7 +86,7 @@ itemsRouter.get('/:id', (req: Request, res: Response, next: NextFunction) => ite
     }
 });
 
-itemsRouter.put('/:id', (req: Request, res: Response, next: NextFunction) => itemFinder(req as ItemRequest, res, next), async (req: Request<{id: string}, {}, ItemUpdateRequest>, res: Response, next: NextFunction): Promise<void> => {
+adminItemsRouter.put('/:id', (req: Request, res: Response, next: NextFunction) => itemFinder(req as ItemRequest, res, next), async (req: Request<{id: string}, {}, ItemUpdateRequest>, res: Response, next: NextFunction): Promise<void> => {
     try {
         const typedReq = req as unknown as ItemRequest;
         const item = typedReq.item;
@@ -103,7 +105,7 @@ itemsRouter.put('/:id', (req: Request, res: Response, next: NextFunction) => ite
 });
 
 // New endpoint to update just the quantity
-itemsRouter.patch('/:id/quantity', (req: Request, res: Response, next: NextFunction) => itemFinder(req as ItemRequest, res, next), async (req: Request<{id: string}, {}, {quantity: number}>, res: Response, next: NextFunction): Promise<void> => {
+adminItemsRouter.patch('/:id/quantity', (req: Request, res: Response, next: NextFunction) => itemFinder(req as ItemRequest, res, next), async (req: Request<{id: string}, {}, {quantity: number}>, res: Response, next: NextFunction): Promise<void> => {
     try {
         const typedReq = req as unknown as ItemRequest;
         const item = typedReq.item;
@@ -121,7 +123,7 @@ itemsRouter.patch('/:id/quantity', (req: Request, res: Response, next: NextFunct
     }
 });
 
-itemsRouter.delete('/:id', (req: Request, res: Response, next: NextFunction) => itemFinder(req as ItemRequest, res, next), async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+adminItemsRouter.delete('/:id', (req: Request, res: Response, next: NextFunction) => itemFinder(req as ItemRequest, res, next), async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
         const typedReq = req as unknown as ItemRequest;
         const item = typedReq.item;
@@ -139,4 +141,4 @@ itemsRouter.delete('/:id', (req: Request, res: Response, next: NextFunction) => 
     }
 });
 
-export { itemsRouter };
+export { privateItemsRouter, publicItemsRouter, adminItemsRouter };

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,7 +4,7 @@ import express from "express";
 import { ErrorRequestHandler } from "express";
 import { PORT } from "./config/config";
 import { connectToDatabase } from "./util/db";
-import { itemsRouter } from "./controllers/items";
+import { adminItemsRouter, privateItemsRouter, publicItemsRouter } from "./controllers/items";
 import { authRouter } from "./controllers/auth";
 import { errorHandler, AppError } from "./middleware/errorHandler";
 import cors from 'cors';
@@ -35,7 +35,7 @@ apiRouter.use(cookieParser());
 apiRouter.use('/auth', authRouter);
 
 // Public items route - no authentication required
-apiRouter.use('/items', itemsRouter);
+apiRouter.use('/items', publicItemsRouter);
 apiRouter.use('/categories', categoriesRouter);
 
 // all the private endpoint starts with /api/private
@@ -57,15 +57,17 @@ privateApiRouter.use('/superadmin', superAdminApiRouter);
 const adminApiRouter = express.Router();
 adminApiRouter.use(verifyAdminSession);
 
-adminApiRouter.use('/', admin)
 // admin related endpoints goes here
+adminApiRouter.use('/items', adminItemsRouter);
 
 privateApiRouter.use('/admin', adminApiRouter);
 
 // all common endpoints for logged in user should use privateApiRouter
-// privateApiRouter.use('/items', itemsRouter);
+privateApiRouter.use('/items', privateItemsRouter);
 
 apiRouter.use('/private', privateApiRouter);
+
+
 
 const errorHandlerMiddleware: ErrorRequestHandler = (err, req, res, next) => {
   errorHandler(err as AppError, req, res, next);


### PR DESCRIPTION
In this PR, segregated items router according to user types. If someone is not logged in , they shouldn't have access to do anything except for checking the items. In admin router only admin can update, delete the items.  For logged in users, they can check items using private endpoints.

Public items router:  api/items
Users items router:  api/private/items
Admin items router: api/private/admin/items